### PR TITLE
use_leaflet set to “false” instead of “true”

### DIFF
--- a/R-3.3.2/library/swimr/rmarkdown/templates/single_scenario/skeleton/skeleton.Rmd
+++ b/R-3.3.2/library/swimr/rmarkdown/templates/single_scenario/skeleton/skeleton.Rmd
@@ -15,7 +15,7 @@ params:
   scenario_name: Reference
   facet: COUNTY
   diff_year: 2040
-  use_leaflet: true
+  use_leaflet: false
 ---
 
 ```{r setup, echo = FALSE, message=FALSE, warning = FALSE}


### PR DESCRIPTION
Parking this hack here for the time being:

Additional parameters of the Rmd templates, such as whether to produce leaflet maps and other parameters, can be changed by altering the values in the header of the Rmd template file itself.

See https://github.com/tlumip/tlumip/issues/111